### PR TITLE
Fix all tests that were using realm: delete all objects form realm on…

### DIFF
--- a/WalletKit/WalletKitTests/Managers/BlockSaverTests.swift
+++ b/WalletKit/WalletKitTests/Managers/BlockSaverTests.swift
@@ -18,6 +18,7 @@ class BlockSaverTests: XCTestCase {
         saver = BlockSaver(realmFactory: mockRealmFactory)
 
         realm = try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: "TestRealm"))
+        try! realm.write { realm.deleteAll() }
 
         initialBlock = Block(header: TestHelper.checkpointBlockHeader, height: 1)
 

--- a/WalletKit/WalletKitTests/Managers/BlockSyncerTests.swift
+++ b/WalletKit/WalletKitTests/Managers/BlockSyncerTests.swift
@@ -20,6 +20,8 @@ class BlockSyncerTests: XCTestCase {
         mockPeerManager = MockPeerManager()
 
         realm = try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: "TestRealm"))
+        try! realm.write { realm.deleteAll() }
+
         peerStatusSubject = PublishSubject()
 
         stub(mockRealmFactory) { mock in
@@ -30,7 +32,7 @@ class BlockSyncerTests: XCTestCase {
             when(mock.statusSubject.get).thenReturn(peerStatusSubject)
         }
 
-        blockSyncer = BlockSyncer(realmFactory: mockRealmFactory, peerManager: mockPeerManager)
+        blockSyncer = BlockSyncer(realmFactory: mockRealmFactory, peerManager: mockPeerManager, scheduler: MainScheduler.instance, queue: .main)
     }
 
     override func tearDown() {
@@ -62,6 +64,7 @@ class BlockSyncerTests: XCTestCase {
 
     func testSync_OnDisconnect() {
         let hash = "000000000000002ca33390dac7a0b98b222b762810f2dda0a00ecf2c1cdf361b".reversedData!
+
         try! realm.write {
             realm.create(Block.self, value: ["reversedHeaderHashHex": hash.reversedHex, "headerHash": hash, "height": 1, "synced": false], update: true)
         }

--- a/WalletKit/WalletKitTests/Managers/HeaderHandlerTests.swift
+++ b/WalletKit/WalletKitTests/Managers/HeaderHandlerTests.swift
@@ -13,8 +13,6 @@ class HeaderHandlerTests: XCTestCase {
 
     private var realm: Realm!
 
-    private var firstCheckPointBlock: Block!
-
     private var initialBlock: Block!
     private var initialHeader: BlockHeader!
 
@@ -28,6 +26,7 @@ class HeaderHandlerTests: XCTestCase {
         headerHandler = HeaderHandler(realmFactory: mockRealmFactory, creator: mockCreator, validator: mockValidator, saver: mockSaver)
 
         realm = try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: "TestRealm"))
+        try! realm.write { realm.deleteAll() }
 
         let preCheckpointBlock = Block(header: TestHelper.preCheckpointBlockHeader, height: TestHelper.preCheckpointBlockHeight)
         try! realm.write {

--- a/WalletKit/WalletKitTests/Managers/HeaderSyncerTests.swift
+++ b/WalletKit/WalletKitTests/Managers/HeaderSyncerTests.swift
@@ -20,6 +20,7 @@ class HeaderSyncerTests: XCTestCase {
         headerSyncer = HeaderSyncer(realmFactory: mockRealmFactory, peerManager: mockPeerManager)
 
         realm = try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: "TestRealm"))
+        try! realm.write { realm.deleteAll() }
 
         let preCheckpointBlock = Block(header: TestHelper.preCheckpointBlockHeader, height: TestHelper.preCheckpointBlockHeight)
         try! realm.write {

--- a/WalletKit/WalletKitTests/Managers/MerkleBlockHandlerTests.swift
+++ b/WalletKit/WalletKitTests/Managers/MerkleBlockHandlerTests.swift
@@ -23,6 +23,7 @@ class MerkleBlockHandlerTests: XCTestCase {
         merkleBlockHandler = MerkleBlockHandler(realmFactory: mockRealmFactory, validator: mockValidator, saver: mockSaver)
 
         realm = try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: "TestRealm"))
+        try! realm.write { realm.deleteAll() }
 
         block = Block()
         block.reversedHeaderHashHex = "00000000000025c23a19cc91ad8d3e33c2630ce1df594e1ae0bf0eabe30a9176"

--- a/WalletKit/WalletKitTests/Managers/TransactionHandlerTests.swift
+++ b/WalletKit/WalletKitTests/Managers/TransactionHandlerTests.swift
@@ -22,6 +22,7 @@ class TransactionHandlerTests: XCTestCase {
         transactionHandler = TransactionHandler(realmFactory: mockRealmFactory, validator: mockValidator, saver: mockSaver)
 
         realm = try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: "TestRealm"))
+        try! realm.write { realm.deleteAll() }
 
         transaction = Transaction()
         transaction.reversedHashHex = Data(hex: "3e7f350bf5c2169833ad02e8ada93a5d47862fe708cdd6c9fb4c15af59e50f70")!.reversedHex


### PR DESCRIPTION
… setup.

Switch peer status subject and realm observer to background threads in BlockSyncer.